### PR TITLE
Docker hub enhancement#19

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@
 
 ## Continuous Integration
 
-Automated continuous integration and deployment occurs in this order: Github commit &#10140; CircleCI Build/Test &#10140; Docker Container &#10140; Tutum Docker Repository &#10140; Tutum Stack &#10140; DigitalOcean Docker Container
+Automated continuous integration and deployment occurs in this order:
+
+Github commit &#10140; CircleCI Build/Test &#10140; Docker Container &#10140; Docker Hub Repository &#10140; Webhook &#10140; Tutum Stack &#10140; DigitalOcean Docker Container
 
 Deployment only occurs from the Master branch and is halted when the CircleCI Build/Test fails.
 
 Type | URL
 ---- | ---
-Master Branch :rocket: | http://foodwatch-haproxy.sjmatta.svc.tutum.io/
+Master Branch :rocket: | http://foodwatch.sjmatta.svc.tutum.io/
 Release :sunny: | Coming soon!

--- a/circle.yml
+++ b/circle.yml
@@ -22,4 +22,3 @@ deployment:
     commands:
       - docker login -e "$HUB_EMAIL" -u "$HUB_USER" -p "$HUB_PASS"
       - docker push sjmatta/foodwatch
-      - curl -d "" "$DEPLOY_URL" > /dev/null 2>&1

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ machine:
 dependencies:
   override:
     - docker info
-    - docker build -t tutum.co/sjmatta/foodwatch .
+    - docker build -t sjmatta/foodwatch .
 
 database:
   override:
@@ -13,13 +13,13 @@ database:
 
 test:
   override:
-    - docker run -d --name foodwatch --link mongo:mongo -e ROOT_URL=http://localhost -e "MONGO_URL=mongodb://$MONGO_PORT_27107_TCP_ADDR:$MONGO_PORT_27017_TCP_PORT/test" -p 80:80 tutum.co/sjmatta/foodwatch
+    - docker run -d --name foodwatch --link mongo:mongo -e ROOT_URL=http://localhost -e "MONGO_URL=mongodb://$MONGO_PORT_27107_TCP_ADDR:$MONGO_PORT_27017_TCP_PORT/test" -p 80:80 sjmatta/foodwatch
     - curl --retry 10 --retry-delay 5 -v http://localhost
 
 deployment:
   hub:
-    branch: master
+    branch: docker-hub-enhancement#19
     commands:
-      - docker login -e "$DOCKER_EMAIL" -u "$DOCKER_USER" -p "$DOCKER_PASS" tutum.co
-      - docker push tutum.co/sjmatta/foodwatch
+      - docker login -e "$HUB_EMAIL" -u "$HUB_USER" -p "$HUB_PASS"
+      - docker push sjmatta/foodwatch
       - curl -d "" "$DEPLOY_URL" > /dev/null 2>&1


### PR DESCRIPTION
Fixes #19. CircleCI now pushes the created Docker image to sjmatta/foodwatch on the public Docker Hub Repository. The Docker Hub Repository is configured to notify Tutum when sjmatta/foodwatch is updated, which triggers a redeploy.